### PR TITLE
Fixed issue that Role and Permissions weren't available after migrating.

### DIFF
--- a/database/migrations/2021_03_20_150445_create_permission_tables.php
+++ b/database/migrations/2021_03_20_150445_create_permission_tables.php
@@ -1,5 +1,6 @@
 <?php
 
+use Database\Seeders\PermissionSeeder;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
@@ -50,8 +51,10 @@ class CreatePermissionTables extends Migration
                 ->on($tableNames['permissions'])
                 ->onDelete('cascade');
 
-            $table->primary(['permission_id', $columnNames['model_morph_key'], 'model_type'],
-                    'model_has_permissions_permission_model_type_primary');
+            $table->primary(
+                ['permission_id', $columnNames['model_morph_key'], 'model_type'],
+                'model_has_permissions_permission_model_type_primary'
+            );
         });
 
         Schema::create($tableNames['model_has_roles'], function (Blueprint $table) use ($tableNames, $columnNames) {
@@ -66,8 +69,10 @@ class CreatePermissionTables extends Migration
                 ->on($tableNames['roles'])
                 ->onDelete('cascade');
 
-            $table->primary(['role_id', $columnNames['model_morph_key'], 'model_type'],
-                    'model_has_roles_role_model_type_primary');
+            $table->primary(
+                ['role_id', $columnNames['model_morph_key'], 'model_type'],
+                'model_has_roles_role_model_type_primary'
+            );
         });
 
         Schema::create($tableNames['role_has_permissions'], function (Blueprint $table) use ($tableNames) {
@@ -90,6 +95,9 @@ class CreatePermissionTables extends Migration
         app('cache')
             ->store(config('permission.cache.store') != 'default' ? config('permission.cache.store') : null)
             ->forget(config('permission.cache.key'));
+
+        $seeder = new PermissionSeeder();
+        $seeder->run();
     }
 
     /**

--- a/tests/Feature/Http/Controllers/PostControllerTest.php
+++ b/tests/Feature/Http/Controllers/PostControllerTest.php
@@ -6,23 +6,12 @@ use App\Models\Category;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class PostControllerTest extends TestCase
 {
     use RefreshDatabase;
     use WithFaker;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Permission::create(['name' => 'create posts']);
-        $userRole = Role::create(['name' => 'user']);
-        $userRole->givePermissionTo('create posts');
-    }
 
     /**
      * @test

--- a/tests/Feature/Http/Controllers/PostReplyControllerTest.php
+++ b/tests/Feature/Http/Controllers/PostReplyControllerTest.php
@@ -7,23 +7,12 @@ use App\Models\PostReply;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class PostReplyControllerTest extends TestCase
 {
     use RefreshDatabase;
     use WithFaker;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Permission::create(['name' => 'create post replies']);
-        $userRole = Role::create(['name' => 'user']);
-        $userRole->givePermissionTo('create post replies');
-    }
 
     /**
      * @test
@@ -38,8 +27,8 @@ class PostReplyControllerTest extends TestCase
             ->from(route('posts.show', $post))
             ->actingAs($user)
             ->post(route('replies.store', $post), [
-            'content' => $content,
-        ]);
+                'content' => $content,
+            ]);
 
         $response->assertRedirect(route('posts.show', $post));
         $response->assertSessionHasNoErrors();

--- a/tests/Feature/Http/Controllers/UserControllerTest.php
+++ b/tests/Feature/Http/Controllers/UserControllerTest.php
@@ -5,23 +5,12 @@ namespace Tests\Feature\Http\Controllers;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
-use Spatie\Permission\Models\Permission;
-use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
 class UserControllerTest extends TestCase
 {
     use RefreshDatabase;
     use WithFaker;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Permission::create(['name' => 'edit own profile']);
-        $userRole = Role::create(['name' => 'user']);
-        $userRole->givePermissionTo('edit own profile');
-    }
 
     /**
      * @test

--- a/tests/Feature/Http/Livewire/AdminAreaCategoriesTest.php
+++ b/tests/Feature/Http/Livewire/AdminAreaCategoriesTest.php
@@ -7,7 +7,6 @@ use App\Models\Category;
 use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Livewire\Livewire;
-use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
@@ -20,10 +19,6 @@ class AdminAreaCategoriesTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        Permission::create(['name' => 'admin categories']);
-        $this->moderatorRole = Role::create(['name' => 'moderator']);
-        $this->moderatorRole->givePermissionTo('admin categories');
 
         $this->testCategory = Category::factory()->create();
         $this->testCategory2 = Category::factory()->create();
@@ -50,7 +45,8 @@ class AdminAreaCategoriesTest extends TestCase
     /** @test */
     public function does_not_show_categories_table_when_the_user_has_no_permission()
     {
-        $this->moderatorRole->revokePermissionTo('admin categories');
+        $moderatorRole = Role::findByName('moderator');
+        $moderatorRole->revokePermissionTo('admin categories');
         $response = $this->get(route('admin-area.categories'));
         $response->assertForbidden()->assertDontSeeLivewire('admin-area-categories');
     }

--- a/tests/Feature/Http/Livewire/AdminAreaUsersTest.php
+++ b/tests/Feature/Http/Livewire/AdminAreaUsersTest.php
@@ -8,7 +8,6 @@ use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Illuminate\Support\Facades\Hash;
 use Livewire\Livewire;
-use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
@@ -25,10 +24,6 @@ class AdminAreaUsersTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
-
-        Permission::create(['name' => 'admin users']);
-        $this->moderatorRole = Role::create(['name' => 'moderator']);
-        $this->moderatorRole->givePermissionTo('admin users');
 
         $this->userRole = Role::create(['name' => 'test-role']);
 
@@ -58,7 +53,8 @@ class AdminAreaUsersTest extends TestCase
      */
     public function it_does_not_show_users_table_when_the_user_has_no_permission()
     {
-        $this->moderatorRole->revokePermissionTo('admin users');
+        $moderatorRole = Role::findByName('moderator');
+        $moderatorRole->revokePermissionTo('admin users');
         $response = $this->get(route('admin-area.users'));
         $response->assertForbidden()->assertDontSeeLivewire('admin-area-users');
     }

--- a/tests/Feature/Http/Livewire/CreatePostTest.php
+++ b/tests/Feature/Http/Livewire/CreatePostTest.php
@@ -8,7 +8,6 @@ use App\Models\User;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Foundation\Testing\WithFaker;
 use Livewire\Livewire;
-use Spatie\Permission\Models\Permission;
 use Spatie\Permission\Models\Role;
 use Tests\TestCase;
 
@@ -18,15 +17,6 @@ class CreatePostTest extends TestCase
     use WithFaker;
 
     private $userRole;
-
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        Permission::create(['name' => 'create posts']);
-        $this->userRole = Role::create(['name' => 'user']);
-        $this->userRole->givePermissionTo('create posts');
-    }
 
     /**
      * @test
@@ -62,10 +52,10 @@ class CreatePostTest extends TestCase
             ->assertSessionHasNoErrors();
 
         $this->assertDatabaseHas('posts', [
-                'title' => $title,
-                'content' => $content,
-                'category_id' => $category->id,
-            ]);
+            'title' => $title,
+            'content' => $content,
+            'category_id' => $category->id,
+        ]);
     }
 
     /**
@@ -115,7 +105,8 @@ class CreatePostTest extends TestCase
     public function it_does_not_store_a_post_when_the_user_has_no_permission()
     {
         $user = User::factory()->create()->assignRole('user');
-        $this->userRole->revokePermissionTo('create posts');
+        $userRole = Role::findByName('user');
+        $userRole->revokePermissionTo('create posts');
         $this->actingAs($user);
 
         $category = Category::factory()->create();


### PR DESCRIPTION
Added seeder execution directly after migrations ran.
